### PR TITLE
Add a definition for an badge_icons extra.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -125,7 +125,10 @@ Content Settings
 
      badge_icon = '/Applications/TextEdit.app/Contents/Resources/Edit.icns'
 
-   Badge icons require pyobjc-framework-Quartz.
+   The use of badge icons requires that ``dmg_build`` be installed with the
+   ``badge_icons`` extra; i.e., you need to install dmg_build using::
+
+      pip install "dmg_build[badge_icons]"
 
 .. py:data:: icon_locations
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,8 @@ docs =
     sphinx
     sphinx-autobuild
     sphinx_rtd_theme
+badge_icons =
+    pyobjc-framework-Quartz >= 3.0.4
 
 [flake8]
 exclude=\

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -17,7 +17,7 @@ def test_sample_json(tmp_path):
     """Test with the sample settings.json file."""
     target = tmp_path / "out.dmg"
     dmgbuild.build_dmg(
-        str(target), "Test", str(Path(__file__).parent / "examples" / "settings.py")
+        str(target), "Test", str(Path(__file__).parent / "examples" / "settings.json")
     )
 
     assert target.exists()


### PR DESCRIPTION
Pyobjc was removed as an explicit dependency; while the docs describe that dependency, we can provide a nicer UX for installing that extra requirement.

Fixes #50.