### PR TITLE
Add support for creating APFS and ULMO compressed disk images

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -42,6 +42,8 @@ Disk Image Settings
    UDCO  Compressed (ADC)
    UDZO  Compressed (gzip)
    UDBZ  Compressed (bzip2)
+   ULFO  Compressed (lzfse - macOS 10.11+ only)
+   ULMO  Compressed (lzma - macOS 10.15+ only)
    UFBI  Entire device
    IPOD  iPod image
    UDxx  UDIF stub
@@ -58,6 +60,11 @@ Disk Image Settings
 
    For disk images you intend to distribute over the Internet, you
    should probably stick to 'UDZO' and 'UDBZ'.
+
+.. py:data:: filesystem
+
+   Specifies the filesystem for the output disk image.  Must be
+   either 'HFS+' (the default) or 'APFS' (macOS 10.13+ only).
 
 .. py:data:: size
 

--- a/src/dmgbuild/core.py
+++ b/src/dmgbuild/core.py
@@ -101,6 +101,7 @@ def load_json(filename, settings):
         (siz.get("width", 640), siz.get("height", 480)),
     )
     settings["format"] = json_data.get("format", "UDZO")
+    settings["filesystem"] = json_data.get("filesystem", "HFS+")
     settings["compression_level"] = json_data.get("compression-level", None)
     settings["license"] = json_data.get("license", None)
     files = []
@@ -155,6 +156,7 @@ def build_dmg(  # noqa; C901
         "filename": filename,
         "volume_name": volume_name,
         "format": "UDBZ",
+        "filesystem": "HFS+",
         "compression_level": None,
         "size": None,
         "files": [],
@@ -460,15 +462,18 @@ def build_dmg(  # noqa; C901
         }
     )
 
+    filesystem = options["filesystem"].upper()
+    fs_args = "-c c=64,a=16,e=16" if filesystem != "APFS" else "" 
+
     ret, output = hdiutil(
         "create",
         "-ov",
         "-volname",
         volume_name,
         "-fs",
-        "HFS+",
+        filesystem,
         "-fsargs",
-        "-c c=64,a=16,e=16",
+        fs_args,
         "-size",
         total_size,
         writableFile.name,
@@ -853,7 +858,7 @@ def build_dmg(  # noqa; C901
         }
     )
 
-    key_prefix = {"UDZO": "zlib", "UDBZ": "bzip2", "ULFO": "lzfse"}
+    key_prefix = {"UDZO": "zlib", "UDBZ": "bzip2", "ULFO": "lzfse", "ULMO": "lzma"}
     compression_level = options["compression_level"]
     if options["format"] in key_prefix and compression_level:
         compression_args = [

--- a/src/dmgbuild/core.py
+++ b/src/dmgbuild/core.py
@@ -463,7 +463,7 @@ def build_dmg(  # noqa; C901
     )
 
     filesystem = options["filesystem"].upper()
-    fs_args = "-c c=64,a=16,e=16" if filesystem != "APFS" else "" 
+    fs_args = "-c c=64,a=16,e=16" if filesystem != "APFS" else ""
 
     ret, output = hdiutil(
         "create",


### PR DESCRIPTION
This adds (mostly documentation) support for creating ULMO (lzma compressed; macOS 10.15+ only) disk images, and for creating APFS disk images (macOS 10.13+ only).

For additional context, lzma can offer significantly reduced compression and is better than bzip2. I've also in some cases found extracting apps from APFS disk images to be more performant than HFS+ (up to 2x or by several seconds depending on the particular workload).