### PR TITLE
Replace setuptools pkg_resources with import lib

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -9,27 +9,21 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: [toml]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
-  - repo: https://github.com/myint/docformatter
-    rev: v1.5.0
-    hooks:
-    - id: docformatter
-      args: [--in-place]
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.3.0
     hooks:
     - id: black
       language_version: python3
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-eradicate==1.4.0]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,9 @@ package_dir =
 install_requires =
     ds_store >= 1.1.0
     mac_alias >= 2.0.1
+    # importlib.resources wasn't fully featured until Python3.9;
+    # install the backwards compatibility shim from Python3.12.
+    importlib_resources == 5.9; python_version <= "3.8"
 
 [options.packages.find]
 where = src

--- a/src/dmgbuild/core.py
+++ b/src/dmgbuild/core.py
@@ -8,7 +8,11 @@ import subprocess
 import tempfile
 import time
 import tokenize
-from importlib import resources
+
+try:
+    import importlib_resources as resources
+except ImportError:
+    from importlib import resources
 
 from ds_store import DSStore
 from mac_alias import Alias, Bookmark
@@ -623,11 +627,9 @@ def build_dmg(  # noqa; C901
                 )
                 if bg_resource.is_file():
                     path_in_image = os.path.join(mount_point, ".background.tiff")
-                    with (
-                        bg_resource.open("rb") as in_file,
-                        open(path_in_image, "wb") as out_file,
-                    ):
-                        out_file.write(in_file.read())
+                    with bg_resource.open("rb") as in_file:
+                        with open(path_in_image, "wb") as out_file:
+                            out_file.write(in_file.read())
                 else:
                     raise ValueError('background file "%s" not found' % background)
 

--- a/src/dmgbuild/core.py
+++ b/src/dmgbuild/core.py
@@ -8,8 +8,8 @@ import subprocess
 import tempfile
 import time
 import tokenize
+from importlib import resources
 
-import pkg_resources
 from ds_store import DSStore
 from mac_alias import Alias, Bookmark
 
@@ -616,18 +616,20 @@ def build_dmg(  # noqa; C901
                 _, kind = os.path.splitext(background)
                 path_in_image = os.path.join(mount_point, ".background" + kind)
                 shutil.copyfile(background, path_in_image)
-            elif pkg_resources.resource_exists(
-                "dmgbuild", "resources/" + background + ".tiff"
-            ):
-                tiffdata = pkg_resources.resource_string(
-                    "dmgbuild", "resources/" + background + ".tiff"
-                )
-                path_in_image = os.path.join(mount_point, ".background.tiff")
-
-                with open(path_in_image, "wb") as f:
-                    f.write(tiffdata)
             else:
-                raise ValueError('background file "%s" not found' % background)
+                dmg_resources = resources.files("dmgbuild")
+                bg_resource = dmg_resources.joinpath(
+                    "resources/" + background + ".tiff"
+                )
+                if bg_resource.is_file():
+                    path_in_image = os.path.join(mount_point, ".background.tiff")
+                    with (
+                        bg_resource.open("rb") as in_file,
+                        open(path_in_image, "wb") as out_file,
+                    ):
+                        out_file.write(in_file.read())
+                else:
+                    raise ValueError('background file "%s" not found' % background)
 
             alias = Alias.for_file(path_in_image)
             background_bmk = Bookmark.for_file(path_in_image)
@@ -883,7 +885,7 @@ def build_dmg(  # noqa; C901
         "-ov",
         "-o",
         filename,
-        *compression_args
+        *compression_args,
     )
 
     callback(


### PR DESCRIPTION
`setuptools.pkg_resources` has been a deprecated API for years; however, the 67.6.1 release has made this a *formal* deprecation, which raises warnings. 

This replaces the deprecated API with the officially supported API.

Includes pre-commit updates because the old config wasn't allowing commits.

Fixes #58 