### PR TITLE
Make subprocess calls raise an exception on non-zero exit codes

### DIFF
--- a/src/dmgbuild/core.py
+++ b/src/dmgbuild/core.py
@@ -550,7 +550,7 @@ def build_dmg(  # noqa; C901
             badge.badge_disk_icon(badge_icon, icon_target_path)
 
         if icon or badge_icon:
-            subprocess.call(["/usr/bin/SetFile", "-a", "C", mount_point])
+            subprocess.check_call(["/usr/bin/SetFile", "-a", "C", mount_point])
 
         background_bmk = None
 
@@ -671,7 +671,7 @@ def build_dmg(  # noqa; C901
             )
 
             # use system ditto command to preserve code signing, etc.
-            subprocess.call(["/usr/bin/ditto", f, f_in_image])
+            subprocess.check_call(["/usr/bin/ditto", f, f_in_image])
 
             callback(
                 {
@@ -736,7 +736,7 @@ def build_dmg(  # noqa; C901
             to_hide.append(name_in_image)
 
         if to_hide:
-            subprocess.call(["/usr/bin/SetFile", "-a", "E"] + to_hide)
+            subprocess.check_call(["/usr/bin/SetFile", "-a", "E"] + to_hide)
 
         to_hide = []
         for name in options["hide"]:
@@ -744,7 +744,7 @@ def build_dmg(  # noqa; C901
             to_hide.append(name_in_image)
 
         if to_hide:
-            subprocess.call(["/usr/bin/SetFile", "-a", "V"] + to_hide)
+            subprocess.check_call(["/usr/bin/SetFile", "-a", "V"] + to_hide)
 
         callback(
             {


### PR DESCRIPTION
The Python function [`subprocess.call()`](https://docs.python.org/3/library/subprocess.html#subprocess.call) does not raise an exception when the command returns a non-zero exit code, i.e. it fails.  This function is used in four places, but the most critical one is `subprocess.call(["/usr/bin/ditto", f, f_in_image])`.  If not enough space is allocated for the `.dmg`, this command will fail and output to stderr,
```
ditto: /Volumes/Volume 1/foo.bar: No space left on device
```
Because the return code of this call is not validated, dmgbuild continues merrily, which can cause a broken release when happening as a part of a deployment process.

Replace all `subprocess.call()` functions with [`subprocess.check_call()`](https://docs.python.org/3/library/subprocess.html#subprocess.check_call) to ensure that an error like this raises an exception and causes the process to fail.  `subprocess.check_call()` is already used in other places in the code.