### PR TITLE
Add a README note about being macOS specific.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,9 @@ when the user opens it.
 without relying on Finder, and without using deprecated APIs (like the
 Alias Manager functions).
 
+``dmgbuild`` is a wrapper around macOS specific tools, so it can't be used on
+Windows or Linux.
+
 See the documentation_ for more information.
 
 .. _documentation: http://dmgbuild.readthedocs.io

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,9 @@ APIs (like the Alias Manager functions).  Instead, it uses the
 ``ds_store`` and ``mac_alias`` Python modules, which know how to
 construct the relevant data in Python code.
 
+As ``dmgbuild`` is a wrapper around macOS specific tools, it can't be used on
+Windows or Linux.
+
 Contents:
 
 .. toctree::


### PR DESCRIPTION
The README doesn't explicitly say that it's macOS specific tool.  It does now.

Fixes #63.