### PR TITLE
Fix intepreter

### DIFF
--- a/src/dmgbuild/__main__.py
+++ b/src/dmgbuild/__main__.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import argparse
 
 from .core import build_dmg


### PR DESCRIPTION
Apple removed the 'python' executable a long time ago, so it's better to default to python3 instead.