### PR TITLE
Fix docs environment to Python 3.12.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,15 +61,10 @@ dev = [
     "pytest-cov == 5.0.0",
     "tox == 4.16.0",
 ]
+# Docs are always built on Py3.12; see RTD and tox config files.
 docs = [
-    # Sphinx 7.2 deprecated support for Python 3.8
-    # Sphinx 8.0 deprecated support for Python 3.9
-    "sphinx == 7.1.2 ; python_version <= '3.8'",
-    "sphinx == 8.0.2 ; python_version == '3.9'",
-    "sphinx == 7.4.7 ; python_version >= '3.10'",
-    # sphinx-autobuild 2024.2.4 deprecated support for Python 3.8
-    "sphinx-autobuild == 2021.3.14 ; python_version < '3.9'",
-    "sphinx-autobuild == 2024.4.16 ; python_version >= '3.9'",
+    "sphinx == 7.4.7",
+    "sphinx-autobuild == 2024.4.16",
     "sphinx_rtd_theme == 2.0.0"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,9 @@ dev = [
 ]
 # Docs are always built on Py3.12; see RTD and tox config files.
 docs = [
+    "furo == 2024.7.18",
     "sphinx == 7.4.7",
     "sphinx-autobuild == 2024.4.16",
-    "sphinx_rtd_theme == 2.0.0"
 ]
 
 [tool.setuptools.dynamic]

--- a/tox.ini
+++ b/tox.ini
@@ -27,17 +27,8 @@ build_dir = _build
 change_dir = docs
 extras =
     docs
-# -W: make warnings into errors
-# --keep-going: continue on errors
-# -j: run with multiple processes
-# -n: nitpick mode
-# -v: verbose logging
-# -E: force rebuild of environment
-# -T: print traceback on error
-# -a: read/parse all files
-# -d: use tox's temp dir for caching
 commands =
-    python -m sphinx build -W --keep-going -j auto -n -v -E -T -a -d _build/doctrees  -b html . _build/html
+    python -m sphinx build --fail-on-warning --keep-going --jobs auto -n --verbose --fresh-env --show-traceback --write-all -d _build/doctrees --builder html . _build/html
 
 [testenv:package]
 skip-install = True

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ commands =
 
 
 [testenv:docs]
+basepython = python3.12
 build_dir = _build
 change_dir = docs
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
 
 
 [testenv:docs]
-basepython = python3.12
+base_python = py312
 build_dir = _build
 change_dir = docs
 extras =


### PR DESCRIPTION
Rather than try to maintain docs dependencies for multiple versions of Python, require that all docs are built on Python 3.12. This is consistent with the RTD configuration, and ensures that there aren't any version discrepancies in rendering (e.g., related to typing changes).