### PR TITLE
Bump black-pre-commit-mirror from 24.4.2 to 24.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     - id: docformatter
       args: [--in-place]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/flake8


### PR DESCRIPTION
Bumps `pre-commit` hook for `black-pre-commit-mirror` from 24.4.2 to 24.8.0 and ran the update against the repo.