### PR TITLE
Make detach behavior more resilient, and capture errors from hdiutil.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
         macOS-version: [
             # x86_64 runners
             "macos-13",
             # M1 runners
-            "macos-14",
+            "macos-latest",
         ]
 
         include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Desktop Environment",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
Modifies the retry behavior when detaching disk images to (a) have more retries, and (b) use exponential backoff in the time between retries. 

Also ensures that stderr content is captured, rather than surfacing to the user. Any stderr content is included in the DMGError that is raised by the API.