### PR TITLE
Bump isort from 5.13.2 to 6.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       - id: isort
         additional_dependencies: [toml]


### PR DESCRIPTION
Bumps `pre-commit` hook for `isort` from 5.13.2 to 6.0.0 and ran the update against the repo.