### PR TITLE
Bump flake8 from 7.1.1 to 7.1.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,6 @@ repos:
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.1.2
     hooks:
       - id: flake8


### PR DESCRIPTION
Bumps `pre-commit` hook for `flake8` from 7.1.1 to 7.1.2 and ran the update against the repo.