### PR TITLE
Ensure that if hdiutil is producing parseable content, stderr isn't included.

### DIFF
--- a/src/dmgbuild/core.py
+++ b/src/dmgbuild/core.py
@@ -54,10 +54,10 @@ def hdiutil(cmd, *args, **kwargs):
     p = subprocess.Popen(
         all_args,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=None if plist else subprocess.STDOUT,
         close_fds=True,
     )
-    output, errors = p.communicate()
+    output, _ = p.communicate()
     if plist:
         results = plistlib.loads(output)
     else:


### PR DESCRIPTION
If `hdiutil` is invoked in plist parsing mode, we need to ensure that stderr content isn't included in stdout, because that can cause parsing errors. Instead of piping `stderr` to `stdout`, leave stderr content as untouched so it will surface to the user.

Fixes #197.