### PR TITLE
Restore badge_icons extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ docs = [
     "sphinx == 8.2.3",
     "sphinx-autobuild == 2024.10.3",
 ]
+badge_icons = [
+    "pyobjc-framework-Quartz >= 3.0.4"
+]
 
 [tool.setuptools.dynamic]
 version = {attr = "dmgbuild.__version__"}


### PR DESCRIPTION
Fixes #214.

In the conversion to PEP 621 metadata in #68, the `badge_icons` extra was neglected. This restores the extra definition.