### PR TITLE
fix: Respect `text-size` property in  JSON `settings` processor

### DIFF
--- a/src/dmgbuild/core.py
+++ b/src/dmgbuild/core.py
@@ -102,6 +102,9 @@ def load_json(filename, settings):
     if bk is not None:
         settings["background"] = bk
     settings["icon_size"] = json_data.get("icon-size", 80)
+    tsize = json_data.get("text-size", None)
+    if tsize is not None:
+        settings["text_size"] = tsize
     wnd = json_data.get(
         "window",
         {


### PR DESCRIPTION
Labeling technically as a `fix` since the property is already existing
https://github.com/dmgbuild/dmgbuild/blob/42ff59afb50907c6305cdbc658d34e6fe3a81828/src/dmgbuild/core.py#L201

It is configurable when using a `.py` settings file per repo's example: https://github.com/dmgbuild/dmgbuild/blob/42ff59afb50907c6305cdbc658d34e6fe3a81828/tests/examples/settings.py#L133

But it is not respected when parsing a JSON config file. Fix is to just add the `json_data.get` 😄 

Note: `text-size` with hyphenation is to mirror the `icon-size` format above it.

Testing:
- Been running this patch in production on 1.6.5 for quite a long time in https://www.npmjs.com/package/dmg-builder?activeTab=versions vendor dir. 100k+ weekly downloads, no issue reports. 😅 
- https://github.com/electron-userland/electron-builder/blame/6c20eeb1cf9fd10980cde3c9ce0602fa6b7c6972/packages/dmg-builder/vendor/dmgbuild/core.py#L105-L107